### PR TITLE
Adds GetAll method

### DIFF
--- a/context.go
+++ b/context.go
@@ -49,12 +49,12 @@ func GetOk(r *http.Request, key interface{}) (interface{}, bool) {
 }
 
 // GetAll returns all stored values for the request as a map. Nil is returned for invalid requests.
-func GetAll(r *http.Request) *map[interface{}]interface{} {
+func GetAll(r *http.Request) map[interface{}]interface{} {
 	mutex.Lock()
 	defer mutex.Unlock()
 
 	if context, ok := data[r]; ok {
-		return &context
+		return context
 	}
 	return nil
 }

--- a/context_test.go
+++ b/context_test.go
@@ -54,7 +54,7 @@ func TestContext(t *testing.T) {
 
 	// GetAll()
 	values := GetAll(r)
-	assertEqual(len(*values), 3)
+	assertEqual(len(values), 3)
 
 	// GetAll() for empty request
 	values = GetAll(emptyR)


### PR DESCRIPTION
I have added a single method `GetAll(r *http.Request) map[interface{}]interface{}` that returns the full context of an request, when exists; otherwise, an empty map. This feature is useful if you want to get the full context of an request.
