### PR TITLE
Remove use of a global lock

### DIFF
--- a/context.go
+++ b/context.go
@@ -5,87 +5,94 @@
 package context
 
 import (
+	"io"
 	"net/http"
-	"sync"
-	"time"
 )
 
-var (
-	mutex sync.RWMutex
-	data  = make(map[*http.Request]map[interface{}]interface{})
-	datat = make(map[*http.Request]int64)
-)
+type attributeStore map[interface{}]interface{}
+
+type decoratedReadCloser struct {
+	body       io.ReadCloser
+	attributes *attributeStore
+}
+
+func decorate(r *http.Request) *decoratedReadCloser {
+	result := decoratedReadCloser{body: r.Body}
+	r.Body = &result
+	return &result
+}
+
+func (w *decoratedReadCloser) Read(p []byte) (n int, err error) {
+	return w.body.Read(p)
+}
+
+func (w *decoratedReadCloser) Close() error {
+	return w.body.Close()
+}
+
+func attributes(r *http.Request) attributeStore {
+	if atts, ok := peekAttributes(r); ok {
+		return *atts
+	}
+
+	atts := make(attributeStore)
+
+	// decorate the request
+	decorator := decorate(r)
+	decorator.attributes = &atts
+
+	return atts
+}
+
+func peekAttributes(r *http.Request) (*attributeStore, bool) {
+	if v, ok := r.Body.(*decoratedReadCloser); ok {
+		return v.attributes, true
+	}
+	return nil, false
+}
 
 // Set stores a value for a given key in a given request.
 func Set(r *http.Request, key, val interface{}) {
-	mutex.Lock()
-	if data[r] == nil {
-		data[r] = make(map[interface{}]interface{})
-		datat[r] = time.Now().Unix()
-	}
-	data[r][key] = val
-	mutex.Unlock()
+	data := attributes(r)
+	data[key] = val
 }
 
 // Get returns a value stored for a given key in a given request.
 func Get(r *http.Request, key interface{}) interface{} {
-	mutex.RLock()
-	if ctx := data[r]; ctx != nil {
-		value := ctx[key]
-		mutex.RUnlock()
-		return value
+	data := attributes(r)
+	if v, ok := data[key]; ok {
+		return v
 	}
-	mutex.RUnlock()
 	return nil
 }
 
 // GetOk returns stored value and presence state like multi-value return of map access.
 func GetOk(r *http.Request, key interface{}) (interface{}, bool) {
-	mutex.RLock()
-	if _, ok := data[r]; ok {
-		value, ok := data[r][key]
-		mutex.RUnlock()
-		return value, ok
-	}
-	mutex.RUnlock()
-	return nil, false
+	data := attributes(r)
+	v, ok := data[key]
+	return v, ok
 }
 
 // GetAll returns all stored values for the request as a map. Nil is returned for invalid requests.
 func GetAll(r *http.Request) map[interface{}]interface{} {
-	mutex.RLock()
-	if context, ok := data[r]; ok {
-		result := make(map[interface{}]interface{}, len(context))
-		for k, v := range context {
-			result[k] = v
-		}
-		mutex.RUnlock()
-		return result
+	if atts, ok := peekAttributes(r); ok {
+		return *atts
 	}
-	mutex.RUnlock()
 	return nil
 }
 
 // GetAllOk returns all stored values for the request as a map and a boolean value that indicates if
 // the request was registered.
 func GetAllOk(r *http.Request) (map[interface{}]interface{}, bool) {
-	mutex.RLock()
-	context, ok := data[r]
-	result := make(map[interface{}]interface{}, len(context))
-	for k, v := range context {
-		result[k] = v
+	if atts, ok := peekAttributes(r); ok {
+		return *atts, ok
 	}
-	mutex.RUnlock()
-	return result, ok
+	return nil, false
 }
 
 // Delete removes a value stored for a given key in a given request.
 func Delete(r *http.Request, key interface{}) {
-	mutex.Lock()
-	if data[r] != nil {
-		delete(data[r], key)
-	}
-	mutex.Unlock()
+	delete(attributes(r), key)
 }
 
 // Clear removes all values stored for a given request.
@@ -93,15 +100,15 @@ func Delete(r *http.Request, key interface{}) {
 // This is usually called by a handler wrapper to clean up request
 // variables at the end of a request lifetime. See ClearHandler().
 func Clear(r *http.Request) {
-	mutex.Lock()
 	clear(r)
-	mutex.Unlock()
 }
 
 // clear is Clear without the lock.
 func clear(r *http.Request) {
-	delete(data, r)
-	delete(datat, r)
+	data := attributes(r)
+	for k := range data {
+		delete(data, k)
+	}
 }
 
 // Purge removes request data stored for longer than maxAge, in seconds.
@@ -114,23 +121,7 @@ func clear(r *http.Request) {
 // amount of memory. In case this is detected, Purge() must be called
 // periodically until the problem is fixed.
 func Purge(maxAge int) int {
-	mutex.Lock()
-	count := 0
-	if maxAge <= 0 {
-		count = len(data)
-		data = make(map[*http.Request]map[interface{}]interface{})
-		datat = make(map[*http.Request]int64)
-	} else {
-		min := time.Now().Unix() - int64(maxAge)
-		for r := range data {
-			if datat[r] < min {
-				clear(r)
-				count++
-			}
-		}
-	}
-	mutex.Unlock()
-	return count
+	return 0
 }
 
 // ClearHandler wraps an http.Handler and clears request values at the end

--- a/context_test.go
+++ b/context_test.go
@@ -32,11 +32,11 @@ func TestContext(t *testing.T) {
 	// Set()
 	Set(r, key1, "1")
 	assertEqual(Get(r, key1), "1")
-	assertEqual(len(data[r]), 1)
+	assertEqual(len(attributes(r)), 1)
 
 	Set(r, key2, "2")
 	assertEqual(Get(r, key2), "2")
-	assertEqual(len(data[r]), 2)
+	assertEqual(len(attributes(r)), 2)
 
 	//GetOk
 	value, ok := GetOk(r, key1)
@@ -75,15 +75,15 @@ func TestContext(t *testing.T) {
 	// Delete()
 	Delete(r, key1)
 	assertEqual(Get(r, key1), nil)
-	assertEqual(len(data[r]), 2)
+	assertEqual(len(attributes(r)), 2)
 
 	Delete(r, key2)
 	assertEqual(Get(r, key2), nil)
-	assertEqual(len(data[r]), 1)
+	assertEqual(len(attributes(r)), 1)
 
 	// Clear()
 	Clear(r)
-	assertEqual(len(data), 0)
+	assertEqual(len(attributes(r)), 0)
 }
 
 func parallelReader(r *http.Request, key string, iterations int, wait, done chan struct{}) {


### PR DESCRIPTION
Request aren’t pooled, so we can wrap the request Body and store
attributes there. This means that each request has its own place to
store attributes, without having to go through a mutex. It also means
that Clear can be dropped in a later release, since the Request will be
eligible for GC and should do our job for us.


Before:
```
> go test -bench .
PASS
BenchmarkMutexSameReadWrite1	  100000	     13965 ns/op
BenchmarkMutexSameReadWrite2	   50000	     28821 ns/op
BenchmarkMutexSameReadWrite4	   30000	     57187 ns/op
BenchmarkMutex1	   20000	     86459 ns/op
BenchmarkMutex2	   10000	    222826 ns/op
BenchmarkMutex3	   20000	     90147 ns/op
BenchmarkMutex4	     200	   7688993 ns/op
BenchmarkMutex5	      30	  50292186 ns/op
BenchmarkMutex6	       5	 298536790 ns/op
ok  	_/Users/jabley/git/context	19.730s
```

With the mutex removed:
```
> go test -bench .
PASS
BenchmarkMutexSameReadWrite1	  100000	     12700 ns/op
BenchmarkMutexSameReadWrite2	   50000	     25692 ns/op
BenchmarkMutexSameReadWrite4	   30000	     50888 ns/op
BenchmarkMutex1	   20000	     71686 ns/op
BenchmarkMutex2	   10000	    197388 ns/op
BenchmarkMutex3	   20000	     77450 ns/op
BenchmarkMutex4	     200	   6996854 ns/op
BenchmarkMutex5	      30	  42156099 ns/op
BenchmarkMutex6	       5	 261614479 ns/op
ok  	_/Users/jabley/git/context	17.295s
```