### PR TITLE
Accept any interface{} to attach context, not just http.Request

### DIFF
--- a/context.go
+++ b/context.go
@@ -12,12 +12,12 @@ import (
 
 var (
 	mutex sync.RWMutex
-	data  = make(map[*http.Request]map[interface{}]interface{})
-	datat = make(map[*http.Request]int64)
+	data  = make(map[interface{}]map[interface{}]interface{})
+	datat = make(map[interface{}]int64)
 )
 
 // Set stores a value for a given key in a given request.
-func Set(r *http.Request, key, val interface{}) {
+func Set(r interface{}, key, val interface{}) {
 	mutex.Lock()
 	if data[r] == nil {
 		data[r] = make(map[interface{}]interface{})
@@ -28,7 +28,7 @@ func Set(r *http.Request, key, val interface{}) {
 }
 
 // Get returns a value stored for a given key in a given request.
-func Get(r *http.Request, key interface{}) interface{} {
+func Get(r interface{}, key interface{}) interface{} {
 	mutex.RLock()
 	if ctx := data[r]; ctx != nil {
 		value := ctx[key]
@@ -40,7 +40,7 @@ func Get(r *http.Request, key interface{}) interface{} {
 }
 
 // GetOk returns stored value and presence state like multi-value return of map access.
-func GetOk(r *http.Request, key interface{}) (interface{}, bool) {
+func GetOk(r interface{}, key interface{}) (interface{}, bool) {
 	mutex.RLock()
 	if _, ok := data[r]; ok {
 		value, ok := data[r][key]
@@ -52,7 +52,7 @@ func GetOk(r *http.Request, key interface{}) (interface{}, bool) {
 }
 
 // GetAll returns all stored values for the request as a map. Nil is returned for invalid requests.
-func GetAll(r *http.Request) map[interface{}]interface{} {
+func GetAll(r interface{}) map[interface{}]interface{} {
 	mutex.RLock()
 	if context, ok := data[r]; ok {
 		result := make(map[interface{}]interface{}, len(context))
@@ -68,7 +68,7 @@ func GetAll(r *http.Request) map[interface{}]interface{} {
 
 // GetAllOk returns all stored values for the request as a map and a boolean value that indicates if
 // the request was registered.
-func GetAllOk(r *http.Request) (map[interface{}]interface{}, bool) {
+func GetAllOk(r interface{}) (map[interface{}]interface{}, bool) {
 	mutex.RLock()
 	context, ok := data[r]
 	result := make(map[interface{}]interface{}, len(context))
@@ -80,7 +80,7 @@ func GetAllOk(r *http.Request) (map[interface{}]interface{}, bool) {
 }
 
 // Delete removes a value stored for a given key in a given request.
-func Delete(r *http.Request, key interface{}) {
+func Delete(r interface{}, key interface{}) {
 	mutex.Lock()
 	if data[r] != nil {
 		delete(data[r], key)
@@ -92,14 +92,14 @@ func Delete(r *http.Request, key interface{}) {
 //
 // This is usually called by a handler wrapper to clean up request
 // variables at the end of a request lifetime. See ClearHandler().
-func Clear(r *http.Request) {
+func Clear(r interface{}) {
 	mutex.Lock()
 	clear(r)
 	mutex.Unlock()
 }
 
 // clear is Clear without the lock.
-func clear(r *http.Request) {
+func clear(r interface{}) {
 	delete(data, r)
 	delete(datat, r)
 }
@@ -118,8 +118,8 @@ func Purge(maxAge int) int {
 	count := 0
 	if maxAge <= 0 {
 		count = len(data)
-		data = make(map[*http.Request]map[interface{}]interface{})
-		datat = make(map[*http.Request]int64)
+		data = make(map[interface{}]map[interface{}]interface{})
+		datat = make(map[interface{}]int64)
 	} else {
 		min := time.Now().Unix() - int64(maxAge)
 		for r := range data {

--- a/context_test.go
+++ b/context_test.go
@@ -86,7 +86,7 @@ func TestContext(t *testing.T) {
 	assertEqual(len(data), 0)
 }
 
-func parallelReader(r *http.Request, key string, iterations int, wait, done chan struct{}) {
+func parallelReader(r interface{}, key string, iterations int, wait, done chan struct{}) {
 	<-wait
 	for i := 0; i < iterations; i++ {
 		Get(r, key)
@@ -95,7 +95,7 @@ func parallelReader(r *http.Request, key string, iterations int, wait, done chan
 
 }
 
-func parallelWriter(r *http.Request, key, value string, iterations int, wait, done chan struct{}) {
+func parallelWriter(r interface{}, key, value string, iterations int, wait, done chan struct{}) {
 	<-wait
 	for i := 0; i < iterations; i++ {
 		Set(r, key, value)


### PR DESCRIPTION
Hey Gorilla team- I assume there's a great reason why Gorilla context doesn't do this, but for my purposes it's exactly what I needed.  Thoughts?

I have two entry points to the API I'm building: 1) the Interface (web consumer) + 2) the Worker (background jobs).

Existing Gorilla Context was perfect through the construction of feature 1. However, in building feature 2 I implemented the code to be seen in this pull request.  For entry point 2, I prefer to attach context to a `*workers.Msg` (as in [github.com/jrallison/go-workers]())

**Example Usage Follows (illustrating #2 above)**

```
/**
  * Entry point to run a Worker instance
  */
func (App *App) DoWork() error {
  log.Printf("Comenzando Trabajador #%s", App.Id )  

  workers.Middleware.Append(&workMiddleware{})

  // pull messages from "contact" with concurrency of 10
  workers.Process(WORK_CONTACT, ContactWorker{App:App}.Handle, 10)

  // stats will be available at this port
  // TODO: worker stats reported to *somewhere*
  // statsPort, _ := strconv.ParseInt(App.StatsPort,0,64)
  // go workers.StatsServer(int(statsPort))

  // Blocks until process is told to exit via unix signal
  if App.IsTesting {
    log.Printf("Porque en pruebas, no trabajó")
  } else { 
    workers.Run()
  }

  return nil;
}

/**
  *  Common Work Processes
  */
type workMiddleware struct{}
func (r *workMiddleware) Call(queue string, message *workers.Msg, next func() bool) (acknowledge bool) {
  // before each message is processed:
  job_json := message.Args().GetIndex(0).MustString()
  job := ContactJob{}
  err := json.Unmarshal([]byte(job_json), &job)
  if err != nil {
    log.Printf("Worker: Could not Unmarshal job job JSON!")
    return
  }
  SetMessageJob(message, job)
  // process the message:
  acknowledge = next()
  // after each message is processed:
  result := GetMessageResult(message)
  result_json, _ := json.Marshal(result)
  log.Printf("Worker: Done! %s", result_json)
  return
} 
//
func queueJob( queue string, job interface{} ) error {
  job_json, err := json.Marshal(job)
  if err != nil {
    log.Printf("Worker: Could not Marshal job JSON! %s", err)
    return err
  }
  _, err = workers.Enqueue(queue, "Add", []string{ string(job_json) } )
  return err
}

/**
  * Contact-related Work
  */
type ContactWorker struct {
  App *App
}
//
func (w ContactWorker) Handle(message *workers.Msg) {
  job := GetMessageJob(message).(ContactJob)
  SetMessageResult(message, w.App.ContactOp.BuildAndSend( job ))
}
//
func (w ContactWorker) Enqueue( job ContactJob ) error {
  return queueJob(WORK_CONTACT, job)
}

/**
  *  Context store
  */
func GetMessageResult(message *workers.Msg) OperationResult {
  if v := context.Get(message, MessageResult); v != nil {
    return v.(OperationResult)
  }
  return OperationResult{}
}
//
func SetMessageResult(message *workers.Msg, v OperationResult) {
  context.Set(message, MessageResult, v)
}
//
func GetMessageJob(message *workers.Msg) interface{} {
  if v := context.Get(message, MessageJob); v != nil {
    return v
  }
  return Payload{}
}
//
func SetMessageJob(message *workers.Msg, v interface{}) {
  context.Set(message, MessageJob, v)
}
```